### PR TITLE
removed import for flag-icon-css from _index.scss

### DIFF
--- a/scss/vendor/_index.scss
+++ b/scss/vendor/_index.scss
@@ -1,5 +1,4 @@
 @import '~@coreui/icons/css/coreui-icons.min.css';
 @import '~font-awesome/scss/font-awesome.scss';
 @import '~simple-line-icons/scss/simple-line-icons.scss';
-@import '~flag-icon-css/css/flag-icon.min.css';
 @import "~@coreui/coreui/scss/coreui";


### PR DESCRIPTION
fix for https://github.com/BRACKETS-by-TRIAD/craftable/issues/157