### PR TITLE
Update dependency of axios from 0.15.3 to 0.19.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -283,8 +283,8 @@
       "dev": true
     },
     "axios": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.15.3.tgz",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
       "integrity": "sha1-LJ1jiy4ZGgjqHWzJiOrda6W9wFM=",
       "requires": {
         "follow-redirects": "1.0.0"


### PR DESCRIPTION
It looks like the axios dependency has not been updated in some time and it comes up as a vulnerability after running the npm install