### PR TITLE
Update axios dependency from 0.15.3 to 0.19.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@coreui/coreui": "^2.1.1",
     "@coreui/icons": "^0.3.0",
-    "axios": "^0.15.3",
+    "axios": "^0.19.2",
     "bootstrap": "^4.1.3",
     "font-awesome": "^4.7.0",
     "jquery": "^3.1.1",


### PR DESCRIPTION
It looks like the axios dependency has not been updated in a long time and comes up as a vulnerability when running npm install