### PR TITLE
chore: added vue-loader to support .vue() on laravel mix

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "babel-preset-es2015": "^6.24.1",
     "cpx": "^1.5.0",
     "node-sass": "^5.0.0",
-    "postcss-cli": "^8.3.1"
+    "postcss-cli": "^8.3.1",
+    "vue-loader": "^15.9.6"
   },
   "files": [
     "/dist",


### PR DESCRIPTION
Related to https://github.com/BRACKETS-by-TRIAD/craftable/issues/308

Vue-loader package is required to support .vue() method on laravel mix